### PR TITLE
chore: clean up error handling

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,53 @@
+class HttpError extends Error {
+  /**
+   * @readonly
+   * @prop {number}
+   */
+  statusCode
+
+  /**
+   * @readonly
+   * @prop {string}
+   */
+  code
+
+  /**
+   * @param {number} statusCode
+   * @param {Uppercase<string>} code
+   * @param {string} message
+   */
+  constructor(statusCode, code, message) {
+    super(message)
+    this.statusCode = statusCode
+    this.code = code
+  }
+}
+
+export const invalidBearerToken = () =>
+  new HttpError(401, 'UNAUTHORIZED', 'Invalid bearer token')
+
+export const projectNotInAllowlist = () =>
+  new HttpError(403, 'PROJECT_NOT_IN_ALLOWLIST', 'Project not allowed')
+
+export const tooManyProjects = () =>
+  new HttpError(
+    403,
+    'TOO_MANY_PROJECTS',
+    'Server is already linked to the maximum number of projects',
+  )
+
+export const projectNotFoundError = () =>
+  new HttpError(404, 'PROJECT_NOT_FOUND', 'Project not found')
+
+/**
+ * @param {string} str
+ * @returns {string}
+ */
+export const normalizeCode = (str) => {
+  switch (str) {
+    case 'FST_ERR_VALIDATION':
+      return 'BAD_REQUEST'
+    default:
+      return str.toUpperCase().replace(/[^A-Z]/gu, '_')
+  }
+}

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -7,6 +7,13 @@ const dateTimeString = Type.String({ format: 'date-time' })
 const latitude = Type.Number({ minimum: -90, maximum: 90 })
 const longitude = Type.Number({ minimum: -180, maximum: 180 })
 
+export const errorResponse = Type.Object({
+  error: Type.Object({
+    code: Type.String(),
+    message: Type.String(),
+  }),
+})
+
 export const projectToAdd = Type.Object({
   projectName: Type.String({ minLength: 1 }),
   projectKey: HEX_STRING_32_BYTES,

--- a/test/add-project-endpoint.js
+++ b/test/add-project-endpoint.js
@@ -20,6 +20,7 @@ test('request missing project name', async (t) => {
   })
 
   assert.equal(response.statusCode, 400)
+  assert.equal(response.json().error.code, 'BAD_REQUEST')
 })
 
 test('request with empty project name', async (t) => {
@@ -32,6 +33,7 @@ test('request with empty project name', async (t) => {
   })
 
   assert.equal(response.statusCode, 400)
+  assert.equal(response.json().error.code, 'BAD_REQUEST')
 })
 
 test('request missing project key', async (t) => {
@@ -44,6 +46,7 @@ test('request missing project key', async (t) => {
   })
 
   assert.equal(response.statusCode, 400)
+  assert.equal(response.json().error.code, 'BAD_REQUEST')
 })
 
 test("request with a project key that's too short", async (t) => {
@@ -56,6 +59,7 @@ test("request with a project key that's too short", async (t) => {
   })
 
   assert.equal(response.statusCode, 400)
+  assert.equal(response.json().error.code, 'BAD_REQUEST')
 })
 
 test('request missing any encryption keys', async (t) => {
@@ -68,6 +72,7 @@ test('request missing any encryption keys', async (t) => {
   })
 
   assert.equal(response.statusCode, 400)
+  assert.equal(response.json().error.code, 'BAD_REQUEST')
 })
 
 test('request missing an encryption key', async (t) => {
@@ -84,6 +89,7 @@ test('request missing an encryption key', async (t) => {
   })
 
   assert.equal(response.statusCode, 400)
+  assert.equal(response.json().error.code, 'BAD_REQUEST')
 })
 
 test("request with an encryption key that's too short", async (t) => {
@@ -100,6 +106,7 @@ test("request with an encryption key that's too short", async (t) => {
   })
 
   assert.equal(response.statusCode, 400)
+  assert.equal(response.json().error.code, 'BAD_REQUEST')
 })
 
 test('adding a project', async (t) => {
@@ -133,7 +140,8 @@ test('adding a second project fails by default', async (t) => {
     body: randomAddProjectBody(),
   })
   assert.equal(response.statusCode, 403)
-  assert.match(response.json().message, /maximum number of projects/u)
+  assert.equal(response.json().error.code, 'TOO_MANY_PROJECTS')
+  assert.match(response.json().error.message, /maximum number of projects/u)
 })
 
 test('allowing a maximum number of projects', async (t) => {
@@ -157,7 +165,8 @@ test('allowing a maximum number of projects', async (t) => {
       body: randomAddProjectBody(),
     })
     assert.equal(response.statusCode, 403)
-    assert.match(response.json().message, /maximum number of projects/u)
+    assert.equal(response.json().error.code, 'TOO_MANY_PROJECTS')
+    assert.match(response.json().error.message, /maximum number of projects/u)
   })
 })
 
@@ -189,6 +198,7 @@ test(
         body: randomAddProjectBody(),
       })
       assert.equal(response.statusCode, 403)
+      assert.equal(response.json().error.code, 'PROJECT_NOT_IN_ALLOWLIST')
     })
   },
 )

--- a/test/allowed-hosts.js
+++ b/test/allowed-hosts.js
@@ -26,4 +26,5 @@ test('disallowed host', async (t) => {
   })
 
   assert.equal(response.statusCode, 403)
+  assert.equal(response.json().error.code, 'FORBIDDEN')
 })

--- a/test/list-projects-endpoint.js
+++ b/test/list-projects-endpoint.js
@@ -18,7 +18,8 @@ test('listing projects', async (t) => {
       url: '/projects',
       headers: { Authorization: 'Bearer bad' },
     })
-    assert.equal(response.statusCode, 403)
+    assert.equal(response.statusCode, 401)
+    assert.equal(response.json().error.code, 'UNAUTHORIZED')
   })
 
   await t.test('with no projects', async () => {

--- a/test/observations-endpoint.js
+++ b/test/observations-endpoint.js
@@ -26,17 +26,18 @@ const FIXTURE_PREVIEW_PATH = new URL('preview.jpg', FIXTURES_ROOT).pathname
 const FIXTURE_THUMBNAIL_PATH = new URL('thumbnail.jpg', FIXTURES_ROOT).pathname
 const FIXTURE_AUDIO_PATH = new URL('audio.mp3', FIXTURES_ROOT).pathname
 
-test('returns a 403 if no auth is provided', async (t) => {
+test('returns a 401 if no auth is provided', async (t) => {
   const server = createTestServer(t)
 
   const response = await server.inject({
     method: 'GET',
     url: `/projects/${randomProjectPublicId()}/observations`,
   })
-  assert.equal(response.statusCode, 403)
+  assert.equal(response.statusCode, 401)
+  assert.equal(response.json().error.code, 'UNAUTHORIZED')
 })
 
-test('returns a 403 if incorrect auth is provided', async (t) => {
+test('returns a 401 if incorrect auth is provided', async (t) => {
   const server = createTestServer(t)
 
   const response = await server.inject({
@@ -44,7 +45,8 @@ test('returns a 403 if incorrect auth is provided', async (t) => {
     url: `/projects/${randomProjectPublicId()}/observations`,
     headers: { Authorization: 'Bearer bad' },
   })
-  assert.equal(response.statusCode, 403)
+  assert.equal(response.statusCode, 401)
+  assert.equal(response.json().error.code, 'UNAUTHORIZED')
 })
 
 test('returning no observations', async (t) => {

--- a/test/sync-endpoint.js
+++ b/test/sync-endpoint.js
@@ -22,7 +22,7 @@ test('sync endpoint is available after adding a project', async (t) => {
       },
     })
     assert.equal(response.statusCode, 404)
-    assert.equal(response.json().error, 'Not Found')
+    assert.equal(response.json().error.code, 'PROJECT_NOT_FOUND')
   })
 
   await server.inject({
@@ -51,5 +51,5 @@ test('sync endpoint returns error with an invalid project public ID', async (t) 
   })
 
   assert.equal(response.statusCode, 400)
-  assert.equal(response.json().code, 'FST_ERR_VALIDATION')
+  assert.equal(response.json().error.code, 'BAD_REQUEST')
 })


### PR DESCRIPTION
This change:

- Normalizes response bodies to something like this:

  ```json
  {
    "error": {
      "code": "SOMETHING_BAD",
      "message": "Something went wrong"
    }
  }
  ```

- Adds error codes for various errors

- Changes some 403s to 401s for correctness

See also: <https://github.com/digidem/comapeo-core/pull/955>