### PR TITLE
chore: Use correct format for declaring env vars in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN npm ci --omit=dev
 # --------------> The production image__
 FROM node:${NODE_VERSION}-bullseye-slim
 
-ENV NODE_ENV production
-ENV PORT 8080
+ENV NODE_ENV=production
+ENV PORT=8080
 EXPOSE 8080
 COPY --from=build /usr/bin/dumb-init /usr/bin/dumb-init
 USER node


### PR DESCRIPTION
When building the Dockerfile I spotted a few legacy key value format warnings. This PR fixes that by replacing the [deprecated](https://docs.docker.com/reference/build-checks/legacy-key-value-format/) `ENV key value` format with `ENV key=value`.