### PR TITLE
chore: Add note about need to configure WebSockets for nginx reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Server configuration is done using environment variables. The following environm
 | `ALLOWED_PROJECTS`    | No       | Number of projects allowed to register with the server               | `1`              |
 | `STORAGE_DIR`         | No       | Path for storing app & project data                                  | `$CWD/data`      |
 
+If you are using Nginx to act as a reverse proxy for your CoMapeo Cloud server, ensure your proxy headers are configured to support WebSockets.
+
 ### Deploying with fly.io
 
 CoMapeo Cloud can be deployed on [fly.io](https://fly.io) using the following steps:


### PR DESCRIPTION
Earlier, we learned that WebSockets support needs to be enabled for a PaaS service like CapRover. CapRover uses nginx for reverse proxy management. So I'm proposing to add a note about that need for use cases where nginx is acting as a reverse proxy for a CoMapeo Cloud server.