### PR TITLE
feat: Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,4 +48,3 @@ jobs:
           npm-token: ${{ secrets.NPM_TOKEN }}
           build-command: |
             npm ci
-            npm run build


### PR DESCRIPTION
Taken from comapeo-schema.

Do we need to set the NPM token or is it already set at the org level?